### PR TITLE
refactor: use Element.animate()

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -89,26 +89,30 @@ const Home: NextPage = () => {
       });
     }
 
-    let i = 0;
-    const animate = () => {
-      const elem = techPrefixRef.current;
-      if (!elem) {
-        return;
+    const prefixElem = techPrefixRef.current;
+    if (!prefixElem) {
+      return;
+    }
+
+    let cancel = false;
+    const animate = async () => {
+      let i = 0;
+      while (!cancel) {
+        const child = prefixElem.children[i];
+        await child.animate(
+          {
+            visibility: "visible",
+            transform: [-30, 0, 0, 30].map((i) => `translateX(${i}px)`),
+            opacity: [0, 1, 1, 0],
+            offset: [0, 0.25, 0.75, 1],
+            easing: "ease",
+          },
+          3000
+        ).finished;
+        i = (i + 1) % prefixElem.children.length;
       }
-
-      const child = elem.children[i];
-      child.classList.remove("invisible");
-      child.classList.add("animate-slide-text");
-      // this SHOULD be the only animation
-      child.getAnimations()[0].finished.then(() => {
-        child.classList.remove("animate-slide-text");
-        child.classList.add("invisible");
-      });
-
-      i = (i + 1) % elem.children.length;
     };
     animate();
-    const interval = setInterval(animate, 3000);
 
     const resetHeight = () => {
       document.documentElement.style.setProperty(
@@ -120,7 +124,7 @@ const Home: NextPage = () => {
     window.addEventListener("resize", resetHeight);
 
     return () => {
-      clearInterval(interval);
+      cancel = true;
       window.removeEventListener("resize", resetHeight);
     };
   }, []);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,7 +28,6 @@ module.exports = {
         "gradient-x-fast": "gradient-x 2s ease infinite",
         "gradient-y": "gradient-y 10s ease infinite",
         "gradient-xy": "gradient-xy 10s ease infinite",
-        "slide-text": "slide-text 3s ease 1",
         "dissolve-text": "dissolve-text ease 1",
         "dissolve-appear": "dissolve-appear 3s ease 1",
         "pulse-and-spin": "pulse 2s infinite, spin 5s linear infinite",
@@ -76,20 +75,6 @@ module.exports = {
           "75%": {
             "background-size": "300% 300%",
             "background-position": "right center",
-          },
-        },
-        "slide-text": {
-          "0%": {
-            transform: "translateX(-30px)",
-            opacity: 0,
-          },
-          "25%, 75%": {
-            transform: "none",
-            opacity: 1,
-          },
-          "100%": {
-            transform: "translateX(30px)",
-            opacity: 0,
           },
         },
         "dissolve-text": {


### PR DESCRIPTION
this lets us get the animation object directly instead of hoping elem.getAnimations()[0] is correct, and removes need to manually add/remove classes